### PR TITLE
修复CPP核心模块编译打包的错误

### DIFF
--- a/cpp/build/build.sh
+++ b/cpp/build/build.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/sh
+#!/bin/sh
 
 ARGS=$1
 

--- a/cpp/framework/CMakeLists.txt
+++ b/cpp/framework/CMakeLists.txt
@@ -92,7 +92,7 @@ set(FRAMEWORK-TGZ "${CMAKE_BINARY_DIR}/framework.tgz")
 
 #需要压缩的文件
 set(MODULES "tars_install.sh")
-list(APPEND MODULES "tarsnode_install.sh")
+set(MODULES "${MODULES} tarsnode_install.sh")
 
 foreach (MODULE ${DEPENDS_LIST})
     set(MODULES "${MODULES} ${MODULE}")
@@ -104,6 +104,7 @@ FILE(WRITE ${RUN_DEPLOY_COMMAND_FILE} "#deploy framework-tar\n")
 FILE(APPEND ${RUN_DEPLOY_COMMAND_FILE} "EXECUTE_PROCESS(\n")
 FILE(APPEND ${RUN_DEPLOY_COMMAND_FILE} "WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/deploy/\n")
 FILE(APPEND ${RUN_DEPLOY_COMMAND_FILE} "COMMAND cp -rf ${PROJECT_SOURCE_DIR}/deploy/tars_install.sh .\n")
+FILE(APPEND ${RUN_DEPLOY_COMMAND_FILE} "COMMAND cp -rf ${PROJECT_SOURCE_DIR}/deploy/tarsnode_install.sh .\n")
 foreach (MODULE ${DEPENDS_LIST})
     FILE(APPEND ${RUN_DEPLOY_COMMAND_FILE} "COMMAND cp -rf ${PROJECT_SOURCE_DIR}/deploy/${MODULE} .\n")
 endforeach ()


### PR DESCRIPTION
2.打包脚本忘记打包tarsnode_install.sh文件
3.在cmake3.5.1下面，生成的打包脚本有问题,导致打包的时候不能正确打包tars_install.sh和tarsnode_install.sh，生成指令为:
COMMAND tar czfv /home/yocto/tars/Tars/cpp/build/framework.tgz tars_install.sh;tarsnode_install.sh tarsnode tarsregistry tarsAdminRegistry tarspatch tarsconfig
修改后，生成指令为：
COMMAND tar czfv /home/yocto/tars/Tars/cpp/build/framework.tgz tars_install.sh tarsnode_install.sh tarsnode tarsregistry tarsAdminRegistry tarspatch tarsconfig