### PR TITLE
增加notify eType初始化

### DIFF
--- a/cpp/servant/libservant/TarsNotify.cpp
+++ b/cpp/servant/libservant/TarsNotify.cpp
@@ -78,6 +78,7 @@ void TarsRemoteNotify::notify(NOTIFYLEVEL level, const string &sMessage)
         if(_notifyPrx)
         {
             ReportInfo info;
+            info.eType     = 0;
             info.sApp      = _app;
             info.sServer   = _serverName;
             info.sSet      = _setName;


### PR DESCRIPTION
notify的eType类型没有初始化
1.eType变量未初始化
2.这个类型说明也没有