### PR TITLE
[fix bug ] Ignore IOException ,when client first close channnel, cann…

### DIFF
--- a/java/net/src/main/java/com/qq/tars/net/core/nio/TCPSession.java
+++ b/java/net/src/main/java/com/qq/tars/net/core/nio/TCPSession.java
@@ -75,8 +75,12 @@ public class TCPSession extends Session {
         if (this.status == SessionStatus.CLOSED) return;
 
         this.status = SessionStatus.CLOSED;
-        if (channel != null) channel.close();
-        if (key != null) key.cancel();
+        try {
+            if (channel != null) channel.close();
+            if (key != null) key.cancel();
+        }catch(IOException e){
+            /*ignore IOException ,when client first clost connection,it cannot be fast unregisterSession*/
+        }
 
         this.key = null;
         this.channel = null;


### PR DESCRIPTION
 当客户端是短链接的时候 。会有大量的请求到服务器端 ，若客户端先于服务器端close链接的话。会导致链接不能快速的被unregister， 会有Oom的问题。处理掉这个IOException后。可以正常回收