### PR TITLE
tars2php.php  structBodyParseLine $wholeType $defaultValue 未定义

### DIFF
--- a/php/tars2php/src/tars2php.php
+++ b/php/tars2php/src/tars2php.php
@@ -1662,6 +1662,9 @@ class StructParser
      */
     public function structBodyParseLine()
     {
+		$wholeType='';
+		$defaultValue='';
+
         $validLine = false;
 
         $this->state = 'init';


### PR DESCRIPTION
phptar /php/tars2php/src/tars2php.php function structBodyParseLine $wholeType&$defaultValue 在某些情况下会产生未定义的错误，在行数开头赋值可以解决这个问题
<img width="636" alt="undefined" src="https://user-images.githubusercontent.com/1306250/41291257-cd44b04a-6e81-11e8-98d3-2f1f542098ae.png">
